### PR TITLE
docs(react-renderer): rename children to content

### DIFF
--- a/packages/react-renderer/README.md
+++ b/packages/react-renderer/README.md
@@ -59,7 +59,7 @@ const App = () => {
   return (
     <div>
       <RichText
-        children={content}
+        content={content}
         renderers={{
           h1: ({ children }) => <h1 className="text-white">{children}</h1>,
           bold: ({ children }) => <strong>{children}</strong>,


### PR DESCRIPTION
`children` is not a valid prop