### PR TITLE
fix(react): empty thead being renderered

### DIFF
--- a/.changeset/eight-balloons-design.md
+++ b/.changeset/eight-balloons-design.md
@@ -1,0 +1,6 @@
+---
+'@graphcms/rich-text-react-renderer': patch
+'@graphcms/rich-text-types': patch
+---
+
+fix: empty thead being renderered

--- a/packages/react-renderer/src/defaultElements.tsx
+++ b/packages/react-renderer/src/defaultElements.tsx
@@ -42,6 +42,7 @@ export const defaultRemoveEmptyElements: Required<RemoveEmptyElementType> = {
   h4: true,
   h5: true,
   h6: true,
+  table_head: true,
 };
 
 export const elementKeys: { [key: string]: string } = {

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -61,9 +61,22 @@ describe('@graphcms/rich-text-react-renderer', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <h5>
-          Hello World!
-        </h5>
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <p>
+                  Row 1 - Col 1
+                </p>
+              </td>
+              <td>
+                <p>
+                  Row 1 - Col 2
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     `);
   });

--- a/packages/react-renderer/test/content.ts
+++ b/packages/react-renderer/test/content.ts
@@ -14,7 +14,31 @@ export const defaultContent: RichTextContent = [
 
 export const emptyContent: RichTextContent = [
   {
+    type: 'heading-one',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+  {
     type: 'heading-two',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+  {
+    type: 'heading-three',
+    children: [
+      {
+        text: '',
+      },
+    ],
+  },
+  {
+    type: 'heading-four',
     children: [
       {
         text: '',
@@ -25,7 +49,56 @@ export const emptyContent: RichTextContent = [
     type: 'heading-five',
     children: [
       {
-        text: 'Hello World!',
+        text: '',
+      },
+    ],
+  },
+  {
+    type: 'table',
+    children: [
+      {
+        type: 'table_head',
+        children: [
+          {
+            text: '',
+          },
+        ],
+      },
+      {
+        type: 'table_body',
+        children: [
+          {
+            type: 'table_row',
+            children: [
+              {
+                type: 'table_cell',
+                children: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Row 1 - Col 1',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'table_cell',
+                children: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Row 1 - Col 2',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
       },
     ],
   },

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -177,6 +177,7 @@ export interface RemoveEmptyElementType {
   h4?: Boolean;
   h5?: Boolean;
   h6?: Boolean;
+  table_head?: Boolean;
 }
 
 export * from './util/isElement';


### PR DESCRIPTION
Related to [#5](https://github.com/GraphCMS/rich-text/issues/5#issuecomment-874637306).

To reproduce the bug:

- Add a table
- Insert a row
- Insert a column
- Render it, and you'll see the `validateDOMNesting` error (also, on the HTML, you'll find an empty `<thead></thead>`.

Closes MAR-1910.