### PR TITLE
Fix AST shape of a parsed copy-pasted image

### DIFF
--- a/.changeset/tasty-seas-reply.md
+++ b/.changeset/tasty-seas-reply.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/html-to-slate-ast': minor
+---
+
+Fix the AST shape of a converted copy-pasted image

--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -37,6 +37,7 @@ const ELEMENT_TAGS: Record<
     href: el.getAttribute('src'),
     title: Boolean(el.getAttribute('alt')) ? el.getAttribute('alt') : '(Image)',
     openInNewTab: true,
+    children: [{ text: el.getAttribute('src') }],
   }),
   PRE: () => ({ type: 'pre' }),
 };


### PR DESCRIPTION
The issue:
A user pasted a document into a Rich Text field, and the copy-pasted data contained an image that had not been uploaded via GraphCMS's Asset flow.
A copy-pasted image is currently transformed into the following AST:

```
{
  "href": "<href>",
  "type": "link",
  "children": [
    {
      "href": "<href>.png",
      "type": "link",
      "title": "<title>",
      "children": [], <- the issue
      "openInNewTab": true
    }
  ]
}
```

The correct shape of a link would have a text node in `children`. We need to set that node to the `src` value of an image:

```
{
  "href": "<href>",
  "type": "link",
  "children": [
    {
      "href": "<href>.png",
      "type": "link",
      "title": "<title>",
      "children": [{ text: "<href>.png" }],
      "openInNewTab": true
    }
  ]
}
```

A reproduction with and without any text children nodes in a link:

https://user-images.githubusercontent.com/34208415/128049338-6e3522b2-5a09-4a06-80ba-f5684df615f5.mp4

