### PR TITLE
Fix text node when pasting images; sanitize URLs

### DIFF
--- a/.changeset/giant-bottles-whisper.md
+++ b/.changeset/giant-bottles-whisper.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/html-to-slate-ast': minor
+---
+
+Fix text node when pasting images; sanitize URLs

--- a/packages/html-to-slate-ast/package.json
+++ b/packages/html-to-slate-ast/package.json
@@ -47,6 +47,7 @@
   },
   "jest": {},
   "dependencies": {
-    "@graphcms/rich-text-types": "^0.2.0"
+    "@graphcms/rich-text-types": "^0.2.0",
+    "@braintree/sanitize-url": "^5.0.2"
   }
 }

--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -10,15 +10,21 @@ const ELEMENT_TAGS: Record<
   OL: () => ({ type: 'numbered-list' }),
   UL: () => ({ type: 'bulleted-list' }),
   P: () => ({ type: 'paragraph' }),
-  A: (el) => ({
-    type: 'link',
-    href: el.getAttribute('href'),
-    ...(el.hasAttribute('title') && { title: el.getAttribute('title') }),
-    ...(el.hasAttribute('rel') && { rel: el.getAttribute('rel') }),
-    ...(el.hasAttribute('id') && { id: el.getAttribute('id') }),
-    ...(el.hasAttribute('class') && { className: el.getAttribute('class') }),
-    openInNewTab: Boolean(el.getAttribute('target') === '_blank'),
-  }),
+  A: (el) => {
+    const href = el.getAttribute('href');
+    if (href === null) return {};
+    return {
+      type: 'link',
+      href: sanitizeUrl(href),
+      ...(el.hasAttribute('title') && { title: el.getAttribute('title') }),
+      ...(el.hasAttribute('rel') && { rel: el.getAttribute('rel') }),
+      ...(el.hasAttribute('id') && { id: el.getAttribute('id') }),
+      ...(el.hasAttribute('class') && {
+        className: el.getAttribute('class'),
+      }),
+      openInNewTab: Boolean(el.getAttribute('target') === '_blank'),
+    };
+  },
   BLOCKQUOTE: () => ({ type: 'block-quote' }),
   H1: () => ({ type: 'heading-one' }),
   H2: () => ({ type: 'heading-two' }),

--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -1,5 +1,5 @@
 import { jsx } from 'slate-hyperscript';
-
+import { sanitizeUrl } from '@braintree/sanitize-url';
 import type { Element, Mark } from '@graphcms/rich-text-types';
 
 const ELEMENT_TAGS: Record<
@@ -32,13 +32,18 @@ const ELEMENT_TAGS: Record<
   TR: () => ({ type: 'table_row' }),
   TD: () => ({ type: 'table_cell' }),
   TH: () => ({ type: 'table_cell' }),
-  IMG: (el) => ({
-    type: 'link',
-    href: el.getAttribute('src'),
-    title: Boolean(el.getAttribute('alt')) ? el.getAttribute('alt') : '(Image)',
-    openInNewTab: true,
-    children: [{ text: el.getAttribute('src') }],
-  }),
+  IMG: (el) => {
+    const href = el.getAttribute('src');
+    if (href === null) return {};
+    return {
+      type: 'link',
+      href: sanitizeUrl(href),
+      title: Boolean(el.getAttribute('alt'))
+        ? el.getAttribute('alt')
+        : '(Image)',
+      openInNewTab: true,
+    };
+  },
   PRE: () => ({ type: 'pre' }),
 };
 
@@ -131,6 +136,8 @@ function deserialize(el: Node) {
         children: [],
       };
       return jsx('element', attrs, [thead, ...children]);
+    } else if (nodeName === 'IMG') {
+      return jsx('element', attrs, [attrs.href]);
     }
     return jsx('element', attrs, children);
   }

--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -40,13 +40,16 @@ const ELEMENT_TAGS: Record<
   TH: () => ({ type: 'table_cell' }),
   IMG: (el) => {
     const href = el.getAttribute('src');
+    const title = Boolean(el.getAttribute('alt'))
+      ? el.getAttribute('alt')
+      : Boolean(el.getAttribute('title'))
+      ? el.getAttribute('title')
+      : '(Image)';
     if (href === null) return {};
     return {
       type: 'link',
       href: sanitizeUrl(href),
-      title: Boolean(el.getAttribute('alt'))
-        ? el.getAttribute('alt')
-        : '(Image)',
+      title,
       openInNewTab: true,
     };
   },

--- a/packages/html-to-slate-ast/test/image.html
+++ b/packages/html-to-slate-ast/test/image.html
@@ -1,0 +1,7 @@
+<meta charset='utf-8'>
+<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-7b0b047f-7fff-682d-9088-8cdd855aa39b"><span
+    style="font-size:11pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;"><span
+      style="border:none;display:inline-block;overflow:hidden;width:428px;height:428px;"><img
+        title="this is this image&#39;s title"
+        src="https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq"
+        width="428" height="428" style="margin-left:0px;margin-top:0px;" /></span></span></b>

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -505,7 +505,7 @@ test('Converts an image pasted from Google Docs into a link node', () => {
       {
         type: 'link',
         href: 'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
-        title: '(Image)',
+        title: "this is this image's title",
         openInNewTab: true,
         children: [
           {

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -497,3 +497,23 @@ test('Converts word documents', () => {
     ])
   );
 });
+
+test('Converts an image pasted from Google Docs into a link node', () => {
+  return htmlToSlateAST(
+    fs.readFileSync(__dirname + '/image.html').toString()
+  ).then((ast) =>
+    expect(ast).toStrictEqual([
+      {
+        type: 'link',
+        href: 'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
+        title: '(Image)',
+        openInNewTab: true,
+        children: [
+          {
+            text: 'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
+          },
+        ],
+      },
+    ])
+  );
+});

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -326,7 +326,6 @@ test('Transforms Google Docs input', () => {
   );
 });
 
-// Skipped because even though expected and result are the same, they differ on their invisible nonsense whitespace next to the headings
 test('Converts word documents', () => {
   return htmlToSlateAST(
     fs.readFileSync(__dirname + '/word-document.html').toString()

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,6 +908,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braintree/sanitize-url@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz#b23080fa35520e993a8a37a0f5bca26aa4650a48"
+  integrity sha512-NBEJlHWrhQucLhZGHtSxM2loSaNUMajC7KOYJLyfcdW/6goVoff2HoYI3bz8YCDN0wKGbxtUL0gx2dvHpvnWlw==
+
 "@changesets/apply-release-plan@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-5.0.0.tgz#11bf168acecbf4cfa2b0e6425160bac5ceeec1c3"


### PR DESCRIPTION
- [x] Assign an image's `src` as the parsed node's text content. Children must be passed to the `jsx` function as the third argument. Previously, they were returned as part of the `attrs` object.

https://user-images.githubusercontent.com/34208415/128988710-cdb7763b-40b7-40f7-abf7-a623f77b11b9.mp4


- [x] Sanitize anchor's `href`, image's `src`

Resolves ENG-3787