### PR TITLE
Introduce Node interface for Node.js environment

### DIFF
--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -1,7 +1,11 @@
+import { JSDOM } from 'jsdom';
 import { BaseElement, Descendant, Text as SlateText } from 'slate';
 import { jsx } from 'slate-hyperscript';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import type { Element, Mark } from '@graphcms/rich-text-types';
+
+// DOM interfaces
+const { Node } = new JSDOM().window;
 
 const ELEMENT_TAGS: Record<
   HTMLElement['nodeName'],


### PR DESCRIPTION
# Bug

The `isChildNode()` function checks against the native DOM `Node` interface, however this interface is not available in the Node.js environment.

```bash
ReferenceError: Node is not defined
```

# Steps to reproduce

Error above can be reproduced by using the `node-script.js` in `examples/` and passing in the following `htmlString`:

```html
<li><p>test</p></li>
```

# Fix

Instantiate new `JSDOM` window and pull out the `Node` interface for use in the file.