### PR TITLE
Fix links with marks, inline comments, lists

### DIFF
--- a/.changeset/wicked-eyes-run.md
+++ b/.changeset/wicked-eyes-run.md
@@ -2,4 +2,4 @@
 '@graphcms/html-to-slate-ast': minor
 ---
 
-Add marks to links; wrap li tag content in a list-item-child node; add tests
+Add marks to links; apply multiple marks if multiple style attributes are present; wrap li tag content in a list-item-child node; add tests

--- a/.changeset/wicked-eyes-run.md
+++ b/.changeset/wicked-eyes-run.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/html-to-slate-ast': minor
+---
+
+Add marks to links; wrap li tag content in a list-item-child node; add tests

--- a/packages/html-to-slate-ast/examples/node-script.js
+++ b/packages/html-to-slate-ast/examples/node-script.js
@@ -4,9 +4,9 @@
 const { htmlToSlateAST } = require('../dist');
 
 async function main() {
-  const htmlString = '<div><p>test</p></div>';
+  const htmlString = '<ul><li>Hey <a href="thing">link text</a> here</li></ul>';
   const ast = await htmlToSlateAST(htmlString);
-  console.log(ast);
+  console.log(JSON.stringify(ast, null, 2));
 }
 
 main()

--- a/packages/html-to-slate-ast/package.json
+++ b/packages/html-to-slate-ast/package.json
@@ -7,6 +7,7 @@
     "start": "tsdx watch --tsconfig tsconfig.build.json --verbose --noClean",
     "build": "tsdx build --tsconfig tsconfig.build.json",
     "test": "tsdx test --passWithNoTests",
+    "test:watch": "tsdx test --watch --passWithNoTests",
     "lint": "tsdx lint",
     "prepublish": "npm run build"
   },
@@ -47,7 +48,7 @@
   },
   "jest": {},
   "dependencies": {
-    "@graphcms/rich-text-types": "^0.2.0",
-    "@braintree/sanitize-url": "^5.0.2"
+    "@braintree/sanitize-url": "^5.0.2",
+    "@graphcms/rich-text-types": "^0.2.0"
   }
 }

--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -157,7 +157,7 @@ function deserialize<
     const attrs = ELEMENT_TAGS[nodeName](el as HTMLElement);
     // li children must be rendered in spans, like in list plugin
     if (nodeName === 'LI') {
-      // in any case you add a single list-item-child containing the children
+      // in any case we add a single list-item-child containing the children
       const child = jsx('element', { type: 'list-item-child' }, children);
       return jsx('element', attrs, [child]);
     } else if (nodeName === 'TR') {

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -152,6 +152,7 @@ test('Transforms Google Docs input', () => {
               {
                 text: 'Link to Google',
                 underline: true,
+                bold: true,
               },
             ],
           },

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -178,7 +178,12 @@ test('Transforms Google Docs input', () => {
                 type: 'list-item-child',
                 children: [
                   {
-                    text: 'One',
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'One',
+                      },
+                    ],
                   },
                 ],
               },
@@ -191,7 +196,12 @@ test('Transforms Google Docs input', () => {
                 type: 'list-item-child',
                 children: [
                   {
-                    text: 'Two',
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Two',
+                      },
+                    ],
                   },
                 ],
               },
@@ -204,7 +214,12 @@ test('Transforms Google Docs input', () => {
                 type: 'list-item-child',
                 children: [
                   {
-                    text: 'Three',
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Three',
+                      },
+                    ],
                   },
                 ],
               },
@@ -230,7 +245,12 @@ test('Transforms Google Docs input', () => {
                 type: 'list-item-child',
                 children: [
                   {
-                    text: 'One',
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'One',
+                      },
+                    ],
                   },
                 ],
               },
@@ -243,7 +263,12 @@ test('Transforms Google Docs input', () => {
                 type: 'list-item-child',
                 children: [
                   {
-                    text: 'Two',
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Two',
+                      },
+                    ],
                   },
                 ],
               },
@@ -404,7 +429,12 @@ test('Converts word documents', () => {
             children: [
               {
                 type: 'list-item-child',
-                children: [{ text: 'Unordered\u00a0' }],
+                children: [
+                  {
+                    type: 'paragraph',
+                    children: [{ text: 'Unordered\u00a0' }],
+                  },
+                ],
               },
             ],
           },
@@ -413,14 +443,21 @@ test('Converts word documents', () => {
             children: [
               {
                 type: 'list-item-child',
-                children: [{ text: 'Bulleted\u00a0' }],
+                children: [
+                  { type: 'paragraph', children: [{ text: 'Bulleted\u00a0' }] },
+                ],
               },
             ],
           },
           {
             type: 'list-item',
             children: [
-              { type: 'list-item-child', children: [{ text: 'List\u00a0' }] },
+              {
+                type: 'list-item-child',
+                children: [
+                  { type: 'paragraph', children: [{ text: 'List\u00a0' }] },
+                ],
+              },
             ],
           },
         ],
@@ -445,7 +482,9 @@ test('Converts word documents', () => {
             children: [
               {
                 type: 'list-item-child',
-                children: [{ text: 'Ordered\u00a0' }],
+                children: [
+                  { type: 'paragraph', children: [{ text: 'Ordered\u00a0' }] },
+                ],
               },
             ],
           },
@@ -459,7 +498,9 @@ test('Converts word documents', () => {
             children: [
               {
                 type: 'list-item-child',
-                children: [{ text: 'Numbered\u00a0' }],
+                children: [
+                  { type: 'paragraph', children: [{ text: 'Numbered\u00a0' }] },
+                ],
               },
             ],
           },
@@ -471,7 +512,12 @@ test('Converts word documents', () => {
           {
             type: 'list-item',
             children: [
-              { type: 'list-item-child', children: [{ text: 'List\u00a0' }] },
+              {
+                type: 'list-item-child',
+                children: [
+                  { type: 'paragraph', children: [{ text: 'List\u00a0' }] },
+                ],
+              },
             ],
           },
         ],
@@ -619,4 +665,77 @@ test('Transforms pre tags into code-block nodes', () => {
       },
     ])
   );
+});
+
+describe('Should apply marks to anchor text node', () => {
+  test('if the parent has a mark', async () => {
+    const input =
+      '<p><em>Emphasized <a href="www.graphcms.com">link</a></em></p>';
+    const ast = await htmlToSlateAST(input);
+    expect(ast).toStrictEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: 'Emphasized ',
+            italic: true,
+          },
+          {
+            type: 'link',
+            href: 'www.graphcms.com',
+            openInNewTab: false,
+            children: [
+              {
+                italic: true,
+                text: 'link',
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('if the mark is inside the anchor tag', async () => {
+    const input =
+      '<p>Emphasized <a href="www.graphcms.com"><strong>link</strong></a></p>';
+    const ast = await htmlToSlateAST(input);
+
+    expect(ast).toStrictEqual([
+      {
+        type: 'paragraph',
+        children: [
+          { text: 'Emphasized ' },
+          {
+            type: 'link',
+            href: 'www.graphcms.com',
+            openInNewTab: false,
+            children: [{ text: 'link', bold: true }],
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+test('Should ignore inline comments', async () => {
+  const input =
+    '<p>Example<!-- Comment --><a href="www.google.com">Google<!-- Comment in anchor --></a><!-- Comment after anchor --><em>Emphasized text</em></p>';
+  const ast = await htmlToSlateAST(input);
+
+  expect(ast).toStrictEqual([
+    {
+      type: 'paragraph',
+      children: [
+        { text: 'Example' },
+        {
+          type: 'link',
+          href: 'www.google.com',
+          openInNewTab: false,
+          children: [{ text: 'Google' }],
+        },
+        { text: 'Emphasized text', italic: true },
+      ],
+    },
+  ]);
 });


### PR DESCRIPTION
- [x] Apply marks to text nodes that are children of a `link` node. If an anchor tag is wrapped in an element that is parsed as a mark, the children of that anchor must be marked accordingly. Previously, the marks were ignored.
- [x] Apply multiple marks if multiple style attributes are present. Previously, only one attribute was respected.
- [x] Content of a `li` tag should be wrapped in one single `list-item-child` node, without discriminating based on the type of each `child` node.
- [x] Tests added for anchors with marks and inline comments.