### PR TITLE
docs(react): add example for Next.js with placeholder images

### DIFF
--- a/packages/react-renderer/README.md
+++ b/packages/react-renderer/README.md
@@ -529,31 +529,8 @@ const SinglePostPage = ({ data }) => {
   );
 };
 
-// Relevant paths from CMS to Next
 export const getStaticPaths = async () => {
-  const data = await fetchFromGraphCMS({
-    query: `
-      {
-        posts {
-          slug
-        }
-      }`,
-    variables: {},
-    preview: true,
-  });
-
-  const postPaths = data.posts.map((item) => {
-    return {
-      params: {
-        slug: item.slug,
-      },
-    };
-  });
-
-  return {
-    paths: postPaths,
-    fallback: false,
-  };
+  // Get your paths here.
 };
 
 export const getStaticProps = async (context) => {


### PR DESCRIPTION
I was [asked on Slack](https://graphcms.slack.com/archives/C9ERN8GFK/p1638801510191400?thread_ts=1638619040.179500&cid=C9ERN8GFK) to provide my example for generating low-quality image placeholders (LQIP) using Next.js and [Plaiceholder](https://github.com/joe-bell/plaiceholder).

To lower the barrier of entry for newcomers, I wanted to show a complete setup. If needed, the example can be shortened.