### PR TITLE
fix: pass reference for nested embeds

### DIFF
--- a/packages/react-renderer/src/RichText.tsx
+++ b/packages/react-renderer/src/RichText.tsx
@@ -184,6 +184,7 @@ function RenderElement({
         <RenderElements
           content={children as ElementNode[]}
           renderers={renderers}
+          references={references}
         />
       </NodeRenderer>
     );

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -14,6 +14,7 @@ import {
   embedAssetContent,
   simpleH1Content,
   tableContent,
+  nestedEmbedAssetContent,
 } from './content';
 
 describe('@graphcms/rich-text-react-renderer', () => {
@@ -813,6 +814,46 @@ describe('custom embeds and assets', () => {
             custom_post_id_2
           </div>
         </div>
+      </div>
+    `);
+  });
+
+  it('should render nested embeds', () => {
+    const references = [
+      {
+        id: 'ckrus0f14ao760b32mz2dwvgx',
+        url: 'https://media.graphcms.com/7M0lXLdCQfeIDXnT2SVS',
+        mimeType: 'video/mp4',
+      },
+    ];
+
+    const { container } = render(
+      <RichText content={nestedEmbedAssetContent} references={references} />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <p>
+          Inline asset
+          <video
+            controls=""
+            height="100%"
+            src="https://media.graphcms.com/7M0lXLdCQfeIDXnT2SVS"
+            width="100%"
+          >
+            <p>
+              Your browser doesn't support HTML5 video. Here is a
+               
+              <a
+                href="https://media.graphcms.com/7M0lXLdCQfeIDXnT2SVS"
+              >
+                link to the video
+              </a>
+               instead.
+            </p>
+          </video>
+          continued
+        </p>
       </div>
     `);
   });

--- a/packages/react-renderer/test/content.ts
+++ b/packages/react-renderer/test/content.ts
@@ -431,3 +431,27 @@ export const embedAssetContent: RichTextContent = [
     nodeType: 'Asset',
   },
 ];
+
+export const nestedEmbedAssetContent: RichTextContent = [
+  {
+    type: 'paragraph',
+    children: [
+      {
+        text: 'Inline asset',
+      },
+      {
+        type: 'embed',
+        nodeId: 'ckrus0f14ao760b32mz2dwvgx',
+        children: [
+          {
+            text: '',
+          },
+        ],
+        nodeType: 'Asset',
+      },
+      {
+        text: 'continued',
+      },
+    ],
+  },
+];


### PR DESCRIPTION
Hi,

I noticed that currently working with nested inline embeds the references are not correctly passed along (see https://github.com/GraphCMS/rich-text/blob/main/packages/react-renderer/src/RichText.tsx#L184)

This PR passes the references, I also added a test to ensure there are no regressions in the future