### PR TITLE
fix(react): \n not converted to <br />

### DIFF
--- a/.changeset/sweet-bananas-punch.md
+++ b/.changeset/sweet-bananas-punch.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/rich-text-react-renderer': patch
+---
+
+fix \n is not converted to <br />

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -4,7 +4,7 @@ import { htmlToSlateAST } from '@graphcms/html-to-slate-ast';
 describe('Transforms lists', () => {
   test('simple one-level', () => {
     const input = `<ul><li>Class 1. Explosive substances (incl. ammunition, fireworks, flares and certain fertilizers);</li><li>Class 2. Gases:- compressed, liquefied or dissolved under pressure;</li><li>Class 3. Flammable liquids;</li><li>Class 4.1. Flammable solids;</li><li>Class 4.2. Substances liable to spontaneous combustion;</li><li>Class 4.3. Substances which, in contact with water, emit flammable gases;</li><li>Class 5.1. Oxidising substances;</li><li>Class 5.2. Organic peroxides;</li><li>Class 6.1. Toxic substances;</li><li>Class 6.2. Infectious substances;</li><li>Class 8. Corrosive substances; and</li><li>Class 9. Miscellaneous dangerous substances and articles.</li></ul>`;
-    return htmlToSlateAST(input).then((ast) =>
+    return htmlToSlateAST(input).then(ast =>
       expect(ast).toEqual([
         {
           type: 'bulleted-list',
@@ -16,7 +16,8 @@ describe('Transforms lists', () => {
                   type: 'list-item-child',
                   children: [
                     {
-                      text: 'Class 1. Explosive substances (incl. ammunition, fireworks, flares and certain fertilizers);',
+                      text:
+                        'Class 1. Explosive substances (incl. ammunition, fireworks, flares and certain fertilizers);',
                     },
                   ],
                 },
@@ -29,7 +30,8 @@ describe('Transforms lists', () => {
                   type: 'list-item-child',
                   children: [
                     {
-                      text: 'Class 2. Gases:- compressed, liquefied or dissolved under pressure;',
+                      text:
+                        'Class 2. Gases:- compressed, liquefied or dissolved under pressure;',
                     },
                   ],
                 },
@@ -68,7 +70,8 @@ describe('Transforms lists', () => {
                   type: 'list-item-child',
                   children: [
                     {
-                      text: 'Class 4.2. Substances liable to spontaneous combustion;',
+                      text:
+                        'Class 4.2. Substances liable to spontaneous combustion;',
                     },
                   ],
                 },
@@ -81,7 +84,8 @@ describe('Transforms lists', () => {
                   type: 'list-item-child',
                   children: [
                     {
-                      text: 'Class 4.3. Substances which, in contact with water, emit flammable gases;',
+                      text:
+                        'Class 4.3. Substances which, in contact with water, emit flammable gases;',
                     },
                   ],
                 },
@@ -159,7 +163,8 @@ describe('Transforms lists', () => {
                   type: 'list-item-child',
                   children: [
                     {
-                      text: 'Class 9. Miscellaneous dangerous substances and articles.',
+                      text:
+                        'Class 9. Miscellaneous dangerous substances and articles.',
                     },
                   ],
                 },
@@ -172,7 +177,7 @@ describe('Transforms lists', () => {
   });
   test('nested, two leves', () => {
     const input = `<ol><li>First item</li><li>Second item<ul><li>First nested item</li><li>Second nested item<ul><li>First deeply nested item</li></ul></li></ul></li><li>Third item</li></ol>`;
-    return htmlToSlateAST(input).then((ast) => {
+    return htmlToSlateAST(input).then(ast => {
       expect(ast).toEqual([
         {
           type: 'numbered-list',
@@ -282,7 +287,7 @@ describe('Transforms lists', () => {
   });
   test('nested, two leves, with a link', () => {
     const input = `<ol><li>First item</li><li><a href="https://graphcms.com" target="_blank">Second item</a><ul><li>First nested item</li><li>Second nested item<ul><li>First deeply nested item</li></ul></li></ul></li><li>Third item</li></ol>`;
-    return htmlToSlateAST(input).then((ast) => {
+    return htmlToSlateAST(input).then(ast => {
       expect(ast).toEqual([
         {
           type: 'numbered-list',
@@ -406,7 +411,7 @@ test('Transforms top level span into paragraph', () => {
   in fact, is the very CSS and HTML rendered as I type this blog. There are calls to HTML element classes that style
   certain properties. For example, the font-family properties in the ".postArticle-content .graf — p" class has a serif
   font value, hence the text rendered in this article is of the serif family. All this to say, if you as a pro</span>`).then(
-    (ast) =>
+    ast =>
       expect(ast).toEqual([
         {
           type: 'paragraph',
@@ -429,7 +434,7 @@ test('Transforms inner span into paragraph', () => {
   in fact, is the very CSS and HTML rendered as I type this blog. There are calls to HTML element classes that style
   certain properties. For example, the font-family properties in</span><span> the ".postArticle-content .graf — p" class has a serif
   font value, hence the text rendered in this article is of the serif family. All this to say, if you as a pro</span></p>`).then(
-    (ast) =>
+    ast =>
       expect(ast).toEqual([
         {
           type: 'paragraph',
@@ -448,7 +453,7 @@ test('Transforms inner span into paragraph', () => {
 
 test('Transforms inner spans wrapped in a div into paragraph', () => {
   const input = fs.readFileSync(__dirname + '/html_input.html').toString();
-  return htmlToSlateAST(input).then((ast) =>
+  return htmlToSlateAST(input).then(ast =>
     expect(ast).toStrictEqual([
       {
         type: 'paragraph',
@@ -490,7 +495,7 @@ test('Transforms Google Docs input', () => {
   const input = fs
     .readFileSync(__dirname + '/google-docs_input.html')
     .toString();
-  return htmlToSlateAST(input).then((ast) =>
+  return htmlToSlateAST(input).then(ast =>
     expect(ast).toEqual([
       {
         type: 'heading-one',
@@ -761,12 +766,14 @@ test('Transforms Google Docs input', () => {
         children: [
           {
             type: 'link',
-            href: 'https://lh6.googleusercontent.com/TkJFBZvkyXTa602F0gkp2phU0O1eHu96RdKFcQ8l_EOS_CBfcI9jYRixN6sNRFnFiZ-ssbLbnLDReb3FrEZ1MnLr70c5gIvPmhJtV7appyVEDSeHLIRdNwdNzbIqs3l2GOgGLGC5=s0',
+            href:
+              'https://lh6.googleusercontent.com/TkJFBZvkyXTa602F0gkp2phU0O1eHu96RdKFcQ8l_EOS_CBfcI9jYRixN6sNRFnFiZ-ssbLbnLDReb3FrEZ1MnLr70c5gIvPmhJtV7appyVEDSeHLIRdNwdNzbIqs3l2GOgGLGC5=s0',
             title: 'Screenshot 2021-06-10 at 15.56.22.png',
             openInNewTab: true,
             children: [
               {
-                text: 'https://lh6.googleusercontent.com/TkJFBZvkyXTa602F0gkp2phU0O1eHu96RdKFcQ8l_EOS_CBfcI9jYRixN6sNRFnFiZ-ssbLbnLDReb3FrEZ1MnLr70c5gIvPmhJtV7appyVEDSeHLIRdNwdNzbIqs3l2GOgGLGC5=s0',
+                text:
+                  'https://lh6.googleusercontent.com/TkJFBZvkyXTa602F0gkp2phU0O1eHu96RdKFcQ8l_EOS_CBfcI9jYRixN6sNRFnFiZ-ssbLbnLDReb3FrEZ1MnLr70c5gIvPmhJtV7appyVEDSeHLIRdNwdNzbIqs3l2GOgGLGC5=s0',
               },
             ],
           },
@@ -787,7 +794,7 @@ test('Transforms Google Docs input', () => {
 test('Converts word documents', () => {
   return htmlToSlateAST(
     fs.readFileSync(__dirname + '/word-document.html').toString()
-  ).then((ast) =>
+  ).then(ast =>
     expect(ast).toStrictEqual([
       {
         type: 'heading-one',
@@ -979,16 +986,18 @@ test('Converts word documents', () => {
 test('Converts an image pasted from Google Docs into a link node', () => {
   return htmlToSlateAST(
     fs.readFileSync(__dirname + '/image.html').toString()
-  ).then((ast) =>
+  ).then(ast =>
     expect(ast).toStrictEqual([
       {
         type: 'link',
-        href: 'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
+        href:
+          'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
         title: "this is this image's title",
         openInNewTab: true,
         children: [
           {
-            text: 'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
+            text:
+              'https://lh5.googleusercontent.com/EqByyE2l_VVSU6KoXFlkpPjJIBsbMTb4Dkr0cuvy2K5ctn8BoJsDHBXO0rU2wyck72_ZF1rqJ5kJ0iMEjU4Jwf7mKhRaLWoHJAzX5WvpfMytIR9sw3EwBcdQdRlIwSrsQ3odhUYq',
           },
         ],
       },
@@ -999,7 +1008,7 @@ test('Converts an image pasted from Google Docs into a link node', () => {
 test('Reshape an incorrectly structured table', () => {
   return htmlToSlateAST(
     '<table><colgroup><col /><col /></colgroup><thead><tr><th></th></tr></thead><tbody><tr><td></td></tr><tr></tr></tbody></table>'
-  ).then((ast) => {
+  ).then(ast => {
     expect(ast).toStrictEqual([
       {
         type: 'table',
@@ -1076,13 +1085,14 @@ test('Reshape an incorrectly structured table', () => {
 
 test('Transforms pre tags into code-block nodes', () => {
   const input = fs.readFileSync(__dirname + '/pre.html').toString();
-  return htmlToSlateAST(input).then((ast) =>
+  return htmlToSlateAST(input).then(ast =>
     expect(ast).toStrictEqual([
       {
         type: 'code-block',
         children: [
           {
-            text: "  L          TE\n    A       A\n      C    V\n       R A\n       DOU\n       LOU\n      REUSE\n      QUE TU\n      PORTES\n    ET QUI T'\n    ORNE O CI\n     VILISÉ\n    OTE-  TU VEUX\n     LA    BIEN\n    SI      RESPI\n            RER       - Apollinaire",
+            text:
+              "  L          TE\n    A       A\n      C    V\n       R A\n       DOU\n       LOU\n      REUSE\n      QUE TU\n      PORTES\n    ET QUI T'\n    ORNE O CI\n     VILISÉ\n    OTE-  TU VEUX\n     LA    BIEN\n    SI      RESPI\n            RER       - Apollinaire",
           },
         ],
       },

--- a/packages/react-renderer/src/RenderText.tsx
+++ b/packages/react-renderer/src/RenderText.tsx
@@ -3,14 +3,33 @@ import { NodeRendererType, Text } from '@graphcms/rich-text-types';
 
 import { elementKeys } from './defaultElements';
 
+function serialize(text: string) {
+  if (text.includes('\n')) {
+    const splitText = text.split('\n');
+
+    return splitText.map((line, index) => (
+      <React.Fragment key={line}>
+        {line}
+        {index === splitText.length - 1 ? null : <br />}
+      </React.Fragment>
+    ));
+  }
+
+  return text;
+}
+
 export function RenderText({
   textNode,
   renderers,
+  shouldSerialize,
 }: {
   textNode: Text;
   renderers?: NodeRendererType;
+  shouldSerialize: boolean;
 }) {
   const { text, bold, italic, underline, code } = textNode;
+
+  const parsedText = shouldSerialize ? serialize(text) : text;
 
   const Bold = renderers?.[
     elementKeys['bold'] as keyof NodeRendererType
@@ -28,7 +47,7 @@ export function RenderText({
     elementKeys['code'] as keyof NodeRendererType
   ] as React.ElementType;
 
-  let element: ReactNode = text;
+  let element: ReactNode = parsedText;
 
   if (bold && Bold) {
     element = <Bold>{element}</Bold>;

--- a/packages/react-renderer/src/RichText.tsx
+++ b/packages/react-renderer/src/RichText.tsx
@@ -21,15 +21,28 @@ import { elementIsEmpty } from './util/elementIsEmpty';
 
 function RenderNode({
   node,
+  parent,
   renderers,
   references,
 }: {
   node: Node;
+  parent: Node | null;
   renderers?: NodeRendererType;
   references?: EmbedReferences;
 }) {
   if (isText(node)) {
-    return <RenderText textNode={node} renderers={renderers} />;
+    let text = node.text;
+
+    const shouldSerialize =
+      parent && isElement(parent) && parent.type !== 'code-block';
+
+    return (
+      <RenderText
+        textNode={{ ...node, text }}
+        renderers={renderers}
+        shouldSerialize={shouldSerialize as boolean}
+      />
+    );
   }
 
   if (isElement(node)) {
@@ -185,6 +198,7 @@ function RenderElement({
           content={children as ElementNode[]}
           renderers={renderers}
           references={references}
+          parent={element}
         />
       </NodeRenderer>
     );
@@ -193,7 +207,16 @@ function RenderElement({
   return <Fragment />;
 }
 
-function RenderElements({ content, references, renderers }: RichTextProps) {
+type RenderElementsProps = RichTextProps & {
+  parent?: Node | null;
+};
+
+function RenderElements({
+  content,
+  references,
+  renderers,
+  parent,
+}: RenderElementsProps) {
   const elements = getElements({ content });
 
   return (
@@ -202,6 +225,7 @@ function RenderElements({ content, references, renderers }: RichTextProps) {
         return (
           <RenderNode
             node={node}
+            parent={parent || null}
             renderers={renderers}
             references={references}
             key={index}

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -66,7 +66,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <h2>
-
+          
           <a
             href="https://graphcms.com"
           >
@@ -74,7 +74,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
           </a>
         </h2>
         <h2>
-
+          
           <a
             href="https://graphcms.com"
           >
@@ -417,17 +417,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
 
     const { container } = render(<RichText content={content} />);
 
-    expect(container).toMatchInlineSnapshot(`
-      <div>
-        <p>
-          Hello,
-          <br />
-          My name is joão pedro,
-          <br />
-          I'm testing a bug
-        </p>
-      </div>
-    `);
+    expect(container).toMatchSnapshot();
   });
 });
 
@@ -870,7 +860,7 @@ describe('custom embeds and assets', () => {
           >
             <p>
               Your browser doesn't support HTML5 video. Here is a
-
+               
               <a
                 href="https://media.graphcms.com/7M0lXLdCQfeIDXnT2SVS"
               >

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -66,7 +66,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <h2>
-          
+
           <a
             href="https://graphcms.com"
           >
@@ -74,7 +74,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
           </a>
         </h2>
         <h2>
-          
+
           <a
             href="https://graphcms.com"
           >
@@ -401,6 +401,33 @@ describe('@graphcms/rich-text-react-renderer', () => {
     const { container } = render(<RichText content={content} />);
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('should replace all \n in a string with <br /> elements', () => {
+    const content: RichTextContent = [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: "Hello,\n⁠My name is joão pedro,\n⁠I'm testing a bug",
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(<RichText content={content} />);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <p>
+          Hello,
+          <br />
+          My name is joão pedro,
+          <br />
+          I'm testing a bug
+        </p>
+      </div>
+    `);
   });
 });
 
@@ -843,7 +870,7 @@ describe('custom embeds and assets', () => {
           >
             <p>
               Your browser doesn't support HTML5 video. Here is a
-               
+
               <a
                 href="https://media.graphcms.com/7M0lXLdCQfeIDXnT2SVS"
               >

--- a/packages/react-renderer/test/__snapshots__/RichText.test.tsx.snap
+++ b/packages/react-renderer/test/__snapshots__/RichText.test.tsx.snap
@@ -110,6 +110,19 @@ exports[`@graphcms/rich-text-react-renderer should render empty text spaces 1`] 
 </div>
 `;
 
+exports[`@graphcms/rich-text-react-renderer should replace all 
+ in a string with <br /> elements 1`] = `
+<div>
+  <p>
+    Hello,
+    <br />
+    ⁠My name is joão pedro,
+    <br />
+    ⁠I'm testing a bug
+  </p>
+</div>
+`;
+
 exports[`custom embeds and assets should render embed video, image, and audio assets 1`] = `
 <div>
   <img


### PR DESCRIPTION
This PR fixes an issue where `\n` wasn't converted to `<br />`.

Important notes: 

- The `&NoBreak;` entity will still show up, but it's not relevant.
- If the parent node is a code block, the text won't be serialized, as it can break the content.