### PR TITLE
docs: add html-to-slate-ast client example

### DIFF
--- a/packages/html-to-slate-ast/README.md
+++ b/packages/html-to-slate-ast/README.md
@@ -49,6 +49,17 @@ mutation newArticle($title: String!, $content: RichTextAST) {
 }
 ```
 
+For sending the generated output from htmlToSlateAST using a GraphQL client, you should transform it into a RichText compatible object, for example:
+
+```js
+const data = await client.request(newArticleQuery, {
+  title: 'Example title for an article',
+  content: { children: ast },
+});
+```
+
+You can see the full example using [graphql-request](https://github.com/prisma-labs/graphql-request) to mutate the data into GraphCMS [here](https://github.com/GraphCMS/rich-text/blob/main/packages/html-to-slate-ast/examples/graphql-request-script.js)
+
 See the docs about the [Rich Text field type](https://graphcms.com/docs/schema/field-types#rich-text) and [Content Api mutations](https://graphcms.com/docs/content-api/mutations)
 
 ## 📝 License

--- a/packages/html-to-slate-ast/examples/graphql-request-script.js
+++ b/packages/html-to-slate-ast/examples/graphql-request-script.js
@@ -1,0 +1,42 @@
+import { GraphQLClient, gql } from 'graphql-request'
+import { htmlToSlateAST } from '@graphcms/html-to-slate-ast';
+
+const client = new GraphQLClient(`${process.env.GRAPHCMS_ENDPOINT}`, {
+  headers: {
+    Authorization: `Bearer ${process.env.GRAPHCMS_TOKEN}`,
+  },
+});
+
+const newArticleQuery = gql`
+  mutation newArticle($title: String!, $content: RichTextAST) {
+    createArticle(data: { title: $title, content: $content }) {
+      id
+      title
+      content {
+        html
+        raw
+      }
+    }
+  }
+`
+
+async function main() {
+  const htmlString = '<ul><li>Hey <a href="thing">link text</a> here</li></ul>';
+  const ast = await htmlToSlateAST(htmlString);
+
+  // Create a RichText object from the AST
+  const content = {
+    children: ast
+  }
+
+  const data = await client.request(newArticleQuery, {
+    title: 'Example title for an article',
+    content // Pass the RichText object as the content
+  })
+
+  console.log(data)
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => console.error(e));


### PR DESCRIPTION
This PR aims to add an example for usage of the `html-to-slate-ast` using graphql-request. 

Since the output from the `htmlToSlateAST` function is not an RichText object, directly passing this output for the `content` in the currently given documentation example field will not work, so that's why I thought this example would be a good idea.