### PR TITLE
Sanitize URLs for Audio and Video tags

### DIFF
--- a/packages/react-renderer/src/elements/Audio.tsx
+++ b/packages/react-renderer/src/elements/Audio.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import escapeHtml from 'escape-html';
 
 export type AudioProps = {
   url: string;
@@ -8,12 +9,12 @@ export function Audio({ url }: AudioProps) {
   return (
     <audio
       style={{ display: 'block', maxWidth: '100%', height: 'auto' }}
-      src={url}
+      src={escapeHtml(url)}
       controls
     >
       <p>
         Your browser doesn't support HTML5 audio. Here is a{' '}
-        <a href={url}>link to the audio</a> instead.
+        <a href={escapeHtml(url)}>link to the audio</a> instead.
       </p>
     </audio>
   );

--- a/packages/react-renderer/src/elements/Video.tsx
+++ b/packages/react-renderer/src/elements/Video.tsx
@@ -13,7 +13,7 @@ export function Video({ src, width, height, title }: Partial<VideoProps>) {
     >
       <p>
         Your browser doesn't support HTML5 video. Here is a{' '}
-        <a href={src}>link to the video</a> instead.
+        <a href={escapeHtml(src)}>link to the video</a> instead.
       </p>
     </video>
   );


### PR DESCRIPTION
Imported escapeHTML package in Audio and Video elements and sanitized URLs for both.
- Not sure whether this is absolutely needed or not, but I feel it's better if we sanitize URLs for Audio and Video elements.