### PR TITLE
chore: use index as key on line break

### DIFF
--- a/.changeset/cool-books-relax.md
+++ b/.changeset/cool-books-relax.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/rich-text-react-renderer': patch
+---
+
+Use index as key on line break to fix React warning of same keys

--- a/packages/react-renderer/src/RenderText.tsx
+++ b/packages/react-renderer/src/RenderText.tsx
@@ -8,7 +8,7 @@ function serialize(text: string) {
     const splitText = text.split('\n');
 
     return splitText.map((line, index) => (
-      <React.Fragment key={line}>
+      <React.Fragment key={index}>
         {line}
         {index === splitText.length - 1 ? null : <br />}
       </React.Fragment>


### PR DESCRIPTION
Changes the key from `line` to `index`. Since `line` will be empty all the time, using the `index` is the best alternative here.

This fixes the same keys warning from React.

Closes #70 