### PR TITLE
chore: parse GCMS embeds into valid nodes

### DIFF
--- a/.changeset/sour-gifts-glow.md
+++ b/.changeset/sour-gifts-glow.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/html-to-slate-ast': minor
+---
+
+Parse GCMS embeds

--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -8,9 +8,11 @@ import { jsx } from 'slate-hyperscript';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import { Element, Mark } from '@graphcms/rich-text-types';
 
+type AttributesType = Omit<Element, 'children'>;
+
 const ELEMENT_TAGS: Record<
   HTMLElement['nodeName'],
-  (el: HTMLElement) => Omit<Element, 'children'>
+  (el: HTMLElement) => AttributesType
 > = {
   LI: () => ({ type: 'list-item' }),
   OL: () => ({ type: 'numbered-list' }),
@@ -461,7 +463,7 @@ function isInlineElement(element: HTMLElement) {
   );
 }
 
-function getSpanAttributes(element: HTMLElement) {
+function getSpanAttributes(element: HTMLElement): AttributesType | null {
   const names = [];
   if (element.style.textDecoration === 'underline') {
     names.push('U');
@@ -475,10 +477,11 @@ function getSpanAttributes(element: HTMLElement) {
   ) {
     names.push('STRONG');
   }
-  const attrs: Record<string, any> = names.reduce((acc, current) => {
+  if (names.length === 0) return null;
+  const attrs: AttributesType = names.reduce((acc, current) => {
     return { ...acc, ...TEXT_TAGS[current]() };
   }, {});
-  return Object.values(attrs).length > 0 ? attrs : undefined;
+  return attrs;
 }
 
 const parseDomDocument = async (normalizedHTML: string) => {

--- a/packages/html-to-slate-ast/test/index.test.ts
+++ b/packages/html-to-slate-ast/test/index.test.ts
@@ -1172,3 +1172,96 @@ test('Should ignore inline comments', async () => {
     },
   ]);
 });
+
+describe('Should parse embeds', () => {
+  describe('Block embeds', () => {
+    test('Assets', () => {
+      const input = `<div data-gcms-embed-type=\"Asset\" data-gcms-embed-id=\"cl0wps6je01cw0cubrunozmfs\"></div>`;
+      return htmlToSlateAST(input).then(result => {
+        expect(result).toStrictEqual([
+          {
+            type: 'embed',
+            nodeId: 'cl0wps6je01cw0cubrunozmfs',
+            children: [
+              {
+                text: '',
+              },
+            ],
+            nodeType: 'Asset',
+          },
+        ]);
+      });
+    });
+    test('Non-asset models', () => {
+      const input = `<div data-gcms-embed-type=\"SourceModel\" data-gcms-embed-id=\"cl13daqqz00bi08uctxdel1x3\"></div>`;
+      return htmlToSlateAST(input).then(result => {
+        expect(result).toStrictEqual([
+          {
+            type: 'embed',
+            nodeId: 'cl13daqqz00bi08uctxdel1x3',
+            children: [
+              {
+                text: '',
+              },
+            ],
+            nodeType: 'SourceModel',
+          },
+        ]);
+      });
+    });
+  });
+  describe('Inline embeds', () => {
+    test('Asset model', () => {
+      const input = `<p>Some text with an inline asset embed: <span data-gcms-embed-type=\"Asset\" data-gcms-embed-id=\"cl0wps6je01cw0cubrunozmfs\" data-gcms-embed-inline></span></p>`;
+      return htmlToSlateAST(input).then(result => {
+        expect(result).toStrictEqual([
+          {
+            type: 'paragraph',
+            children: [
+              {
+                text: 'Some text with an inline asset embed: ',
+              },
+              {
+                type: 'embed',
+                nodeId: 'cl0wps6je01cw0cubrunozmfs',
+                children: [
+                  {
+                    text: '',
+                  },
+                ],
+                isInline: true,
+                nodeType: 'Asset',
+              },
+            ],
+          },
+        ]);
+      });
+    });
+    test('Non-asset model', () => {
+      const input = `<p>Some text with a titled inline embed after it: <span data-gcms-embed-type=\"SourceModel\" data-gcms-embed-id=\"cl13daqqz00bi08uctxdel1x3\" data-gcms-embed-inline></span></p>`;
+      return htmlToSlateAST(input).then(result => {
+        expect(result).toStrictEqual([
+          {
+            type: 'paragraph',
+            children: [
+              {
+                text: 'Some text with a titled inline embed after it: ',
+              },
+              {
+                type: 'embed',
+                nodeId: 'cl13daqqz00bi08uctxdel1x3',
+                children: [
+                  {
+                    text: '',
+                  },
+                ],
+                isInline: true,
+                nodeType: 'SourceModel',
+              },
+            ],
+          },
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Allows parsing GCMS block, inline embeds into valid nodes.