### PR TITLE
chore(deps): add escape-html

### DIFF
--- a/.changeset/pretty-fans-hug.md
+++ b/.changeset/pretty-fans-hug.md
@@ -1,0 +1,5 @@
+---
+'@graphcms/rich-text-html-renderer': patch
+---
+
+Add escape-html as a dependency

--- a/packages/html-renderer/package.json
+++ b/packages/html-renderer/package.json
@@ -12,7 +12,11 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@graphcms/rich-text-types": "^0.4.0"
+    "@graphcms/rich-text-types": "^0.4.0",
+    "escape-html": "^1.0.3"
+  },
+  "devDependencies": {
+    "@types/escape-html": "^1.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-renderer/package.json
+++ b/packages/react-renderer/package.json
@@ -16,7 +16,7 @@
     "escape-html": "^1.0.3"
   },
   "devDependencies": {
-    "@types/escape-html": "^1.0.1"
+    "@types/escape-html": "^1.0.2"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,10 +2566,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/escape-html@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.1.tgz#b19b4646915f0ae2c306bf984dc0a59c5cfc97ba"
-  integrity sha512-4mI1FuUUZiuT95fSVqvZxp/ssQK9zsa86S43h9x3zPOSU9BBJ+BfDkXwuaU7BfsD+e7U0/cUUfJFk3iW2M4okA==
+"@types/escape-html@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.2.tgz#072b7b13784fb3cee9c2450c22f36405983f5e3c"
+  integrity sha512-gaBLT8pdcexFztLSPRtriHeXY/Kn4907uOCZ4Q3lncFBkheAWOuNt53ypsF8szgxbEJ513UeBzcf4utN0EzEwA==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
This PR fixes an issue when rendering an element that depends on the `escape-html` package, which was not installed on the `html-renderer` package.

```
error - ./node_modules/@graphcms/rich-text-html-renderer/dist/rich-text-html-renderer.esm.js:2:0
Module not found: Can’t resolve ‘escape-html’
Import trace for requested module:
./pages/form-sidebar.tsx
```