### PR TITLE
feat: add support for link embeds

### DIFF
--- a/.changeset/giant-lamps-develop.md
+++ b/.changeset/giant-lamps-develop.md
@@ -1,0 +1,7 @@
+---
+'@graphcms/rich-text-types': minor
+---
+
+- Add type `LinkEmbedProps`
+- Update `EmbedElement`
+- Add `id` to `EmbedProps`

--- a/.changeset/serious-masks-compete.md
+++ b/.changeset/serious-masks-compete.md
@@ -1,0 +1,6 @@
+---
+'@graphcms/rich-text-html-renderer': minor
+'@graphcms/rich-text-react-renderer': minor
+---
+
+Adds support for Link Embeds

--- a/packages/html-renderer/README.md
+++ b/packages/html-renderer/README.md
@@ -317,6 +317,46 @@ References are required on the `astToHtmlString` function. You also need to incl
 }
 ```
 
+### Link embeds
+
+The Rich Text Field also supports Link Embeds, which work similarly to normal embeds. Based on the model name, you can have a custom renderer for it. Example:
+
+```js
+import { astToHtmlString } from '@graphcms/rich-text-html-renderer';
+
+const content = [
+  {
+    type: 'link',
+    nodeId: 'post_id',
+    children: [
+      {
+        text: 'click here',
+      },
+    ],
+    nodeType: 'Post',
+  },
+];
+
+const references = [
+  {
+    id: 'post_id',
+    slug: 'graphcms-is-awesome',
+  },
+];
+
+const html = astToHtmlString({
+  content: contentObject,
+  references,
+  renderers: {
+    link: {
+      Article: ({ slug, children }) => {
+        return `<a href="/${slug}">${children}</a>`;
+      },
+    },
+  },
+});
+```
+
 ## Empty elements
 
 By default, we remove empty headings from the element list to prevent SEO issues. Other elements, such as `thead` are also removed. You can find the complete list [here](https://github.com/GraphCMS/rich-text/blob/main/packages/types/src/index.ts#L168).
@@ -343,13 +383,13 @@ type Content = {
 
 ### Custom Embeds/Assets
 
-Depending on your reference query and model, fields may change, which applies to types. To have a better DX using the package, we have `EmbedProps` type that you can import from `@graphcms/rich-text-types` (you may need to install it if you don't have done it already).
+Depending on your reference query and model, fields may change, which applies to types. To have a better DX using the package, we have `EmbedProps` and `LinkEmbedProps` types that you can import from `@graphcms/rich-text-types` (you may need to install it if you don't have done it already).
 
 In this example, we have seen how to write a renderer for a `Post` model, but it applies the same way to any other model and `Asset` on your project.
 
 ```ts
 import { astToHtmlString } from '@graphcms/rich-text-html-renderer';
-import { EmbedProps } from '@graphcms/rich-text-types';
+import { EmbedProps, LinkEmbedProps } from '@graphcms/rich-text-types';
 
 type Post = {
   title: string;
@@ -373,12 +413,17 @@ const html = astToHtmlString({
       Post: ({ title, description, slug }: EmbedProps<Post>) => {
         return `
           <div className="post">
-            <a href="/post/${slug}">
+            <a href="/blog/${slug}">
               <h3>${title}</h3>
               <p>${description}</p>
             </a>
           </div>
         `;
+      },
+    },
+    link: {
+      Article: ({ slug, children }) => {
+        return `<a href="/blog/${slug}">${children}</a>`;
       },
     },
   },

--- a/packages/html-renderer/src/defaultElements.tsx
+++ b/packages/html-renderer/src/defaultElements.tsx
@@ -62,4 +62,5 @@ export const defaultElements: Required<RichTextProps['renderers']> = {
     text: FallbackForCustomAsset,
   },
   embed: {},
+  link: {},
 };

--- a/packages/html-renderer/src/elements/Image.tsx
+++ b/packages/html-renderer/src/elements/Image.tsx
@@ -15,13 +15,10 @@ export function Image({
   }
 
   return `
-    <img
-      loading="lazy"
-      src="${escapeHtml(src)}"
-      width="${width || ''}"
-      height="${height || ''}"
-      alt="${altText || ''}"
-      title="${title || ''}"
-    />
+    <img loading="lazy" src="${escapeHtml(src)}" ${
+    width ? `width="${width}"` : ``
+  } ${height ? `height="${height}"` : ``} ${
+    altText ? `alt="${altText}"` : ``
+  } ${title ? `title="${title}"` : ``} />
   `;
 }

--- a/packages/html-renderer/src/elements/Link.tsx
+++ b/packages/html-renderer/src/elements/Link.tsx
@@ -5,14 +5,11 @@ export function Link({ children, ...rest }: LinkRendererProps) {
   const { href, rel, id, title, openInNewTab, className } = rest;
 
   return `
-    <a
-      href="${escapeHtml(href)}"
-      class="${className || ''}"
-      target="${openInNewTab ? '_blank' : '_self'}"
-      title="${title || ''}"
-      id="${id || ''}"
-      rel="${rel || ''}"
-    >
+    <a href="${escapeHtml(href)}" target="${
+    openInNewTab ? '_blank' : '_self'
+  }" ${className ? `class="${className}"` : ``} ${rel ? `rel="${rel}"` : ``} ${
+    title ? `title="${title}"` : ``
+  } ${id ? `id="${id}"` : ``} ${rel ? `rel="${rel}"` : ``}>
       ${children}
     </a>
   `;

--- a/packages/html-renderer/src/elements/Video.tsx
+++ b/packages/html-renderer/src/elements/Video.tsx
@@ -3,13 +3,8 @@ import { VideoProps } from '@graphcms/rich-text-types';
 
 export function Video({ src, width, height, title }: Partial<VideoProps>) {
   return `
-    <video
-      src="${escapeHtml(src)}"
-      controls
-      width="${width || '100%'}"
-      height="${height || '100%'}"
-      title="${title || ''}"
-    >
+    <video src="${escapeHtml(src)}" controls width="${width ||
+    '100%'}" height="${height || '100%'}" ${title ? `title="${title}"` : ``}>
       <p>
         Your browser doesn't support HTML5 video. Here is a
         <a href="${src}">link to the video</a> instead.

--- a/packages/html-renderer/src/index.ts
+++ b/packages/html-renderer/src/index.ts
@@ -87,7 +87,7 @@ function renderElement({
     return ``;
   }
 
-  const isEmbed = type === 'embed';
+  const isEmbed = nodeId && nodeType;
 
   const referenceValues = isEmbed
     ? references?.filter(ref => ref.id === nodeId)[0]
@@ -125,13 +125,16 @@ function renderElement({
   let elementToRender;
 
   if (isEmbed && nodeType !== 'Asset') {
-    const element = renderers?.embed?.[nodeType as string];
+    const element =
+      type === 'link'
+        ? renderers?.link?.[nodeType as string]
+        : renderers?.embed?.[nodeType as string];
 
     if (element !== undefined) {
       elementToRender = element;
     } else {
       console.warn(
-        `[@graphcms/rich-text-html-renderer]: No renderer found for custom embed node type ${nodeType}.`
+        `[@graphcms/rich-text-html-renderer]: No renderer found for custom ${type} nodeType ${nodeType}.`
       );
       return ``;
     }

--- a/packages/html-renderer/src/types.ts
+++ b/packages/html-renderer/src/types.ts
@@ -70,6 +70,9 @@ export type NodeRendererType = {
   embed?: {
     [key: string]: EmbedNodeRenderer | undefined;
   };
+  link?: {
+    [key: string]: EmbedNodeRenderer | undefined;
+  };
 };
 
 export type RichTextProps = {

--- a/packages/html-renderer/test/__snapshots__/index.test.ts.snap
+++ b/packages/html-renderer/test/__snapshots__/index.test.ts.snap
@@ -2,22 +2,9 @@
 
 exports[`custom embeds and assets should render embed video, image, and audio assets 1`] = `
 "
-    <img
-      loading=\\"lazy\\"
-      src=\\"https://media.graphassets.com/dsQtt0ARqO28baaXbVy9\\"
-      width=\\"\\"
-      height=\\"\\"
-      alt=\\"\\"
-      title=\\"\\"
-    />
+    <img loading=\\"lazy\\" src=\\"https://media.graphassets.com/dsQtt0ARqO28baaXbVy9\\"     />
   
-    <video
-      src=\\"https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS\\"
-      controls
-      width=\\"100%\\"
-      height=\\"100%\\"
-      title=\\"\\"
-    >
+    <video src=\\"https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS\\" controls width=\\"100%\\" height=\\"100%\\" >
       <p>
         Your browser doesn't support HTML5 video. Here is a
         <a href=\\"https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS\\">link to the video</a> instead.

--- a/packages/html-renderer/test/__snapshots__/index.test.ts.snap
+++ b/packages/html-renderer/test/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`custom embeds and assets should render embed video, image, and audio assets 1`] = `
+exports[`custom embeds and assets should render video, image, and audio assets 1`] = `
 "
     <img loading=\\"lazy\\" src=\\"https://media.graphassets.com/dsQtt0ARqO28baaXbVy9\\"     />
   

--- a/packages/html-renderer/test/index.test.ts
+++ b/packages/html-renderer/test/index.test.ts
@@ -1,5 +1,9 @@
 import { astToHtmlString } from '@graphcms/rich-text-html-renderer';
-import { RichTextContent, EmbedProps } from '@graphcms/rich-text-types';
+import {
+  RichTextContent,
+  EmbedProps,
+  LinkEmbedProps,
+} from '@graphcms/rich-text-types';
 
 import {
   defaultContent as content,
@@ -296,7 +300,7 @@ describe('@graphcms/rich-text-html-renderer', () => {
 });
 
 describe('custom embeds and assets', () => {
-  it('should render embed video, image, and audio assets', () => {
+  it('should render video, image, and audio assets', () => {
     const references = [
       {
         id: 'cknjbzowggjo90b91kjisy03a',
@@ -405,6 +409,16 @@ describe('custom embeds and assets', () => {
         nodeType: 'Asset',
       },
       {
+        type: 'link',
+        nodeId: 'link_id',
+        children: [
+          {
+            text: 'click here',
+          },
+        ],
+        nodeType: 'Article',
+      },
+      {
         type: 'embed',
         nodeId: 'custom_post_id',
         children: [
@@ -431,6 +445,10 @@ describe('custom embeds and assets', () => {
         id: '',
         title: 'GraphCMS is awesome :rocket:',
       },
+      {
+        id: '',
+        slug: 'graphcms-is-awesome',
+      },
     ];
 
     /**
@@ -441,7 +459,7 @@ describe('custom embeds and assets', () => {
       references,
     });
 
-    expect(console.error).toHaveBeenCalledTimes(3);
+    expect(console.error).toHaveBeenCalledTimes(4);
     expect(html).toEqual(``);
   });
 
@@ -555,6 +573,47 @@ describe('custom embeds and assets', () => {
     );
   });
 
+  it('should render custom link models', () => {
+    const contentObject: RichTextContent = [
+      {
+        type: 'link',
+        nodeId: 'my_article',
+        children: [
+          {
+            text: 'click here',
+          },
+        ],
+        nodeType: 'Article',
+      },
+    ];
+
+    const references = [
+      {
+        id: 'my_article',
+        slug: 'introducing-link-embeds',
+      },
+    ];
+
+    const html = astToHtmlString({
+      content: contentObject,
+      references,
+      renderers: {
+        link: {
+          Article: ({ slug, children }: LinkEmbedProps<{ slug: string }>) => {
+            return `<a href="${`/${slug}`}">${children}</a>`;
+          },
+        },
+        embed: {
+          Post: ({ title, nodeId }: EmbedProps<{ title: string }>) => {
+            return `<div class="post"><h3>${title}</h3><p>${nodeId}</p></div>`;
+          },
+        },
+      },
+    });
+
+    expect(html).toEqual(`<a href="/introducing-link-embeds">click here</a>`);
+  });
+
   it(`should show a warning if embeds are found but there aren't any renderer for it`, () => {
     console.warn = jest.fn();
 
@@ -569,12 +628,26 @@ describe('custom embeds and assets', () => {
         ],
         nodeType: 'Post',
       },
+      {
+        type: 'link',
+        nodeId: 'link_id',
+        children: [
+          {
+            text: 'My link',
+          },
+        ],
+        nodeType: 'Article',
+      },
     ];
 
     const references = [
       {
         id: 'custom_post_id',
         title: 'GraphCMS is awesome :rocket:',
+      },
+      {
+        id: 'link_id',
+        title: 'My link',
       },
     ];
 
@@ -583,7 +656,7 @@ describe('custom embeds and assets', () => {
       references,
     });
 
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(2);
     expect(html).toEqual(``);
   });
 

--- a/packages/html-renderer/test/index.test.ts
+++ b/packages/html-renderer/test/index.test.ts
@@ -600,12 +600,7 @@ describe('custom embeds and assets', () => {
       renderers: {
         link: {
           Article: ({ slug, children }: LinkEmbedProps<{ slug: string }>) => {
-            return `<a href="${`/${slug}`}">${children}</a>`;
-          },
-        },
-        embed: {
-          Post: ({ title, nodeId }: EmbedProps<{ title: string }>) => {
-            return `<div class="post"><h3>${title}</h3><p>${nodeId}</p></div>`;
+            return `<a href="/${slug}">${children}</a>`;
           },
         },
       },

--- a/packages/html-renderer/test/index.test.ts
+++ b/packages/html-renderer/test/index.test.ts
@@ -46,25 +46,11 @@ describe('@graphcms/rich-text-html-renderer', () => {
     const html = astToHtmlString({ content: emptyContent });
 
     expect(html).toEqual(`<h2>
-    <a
-      href="https://graphcms.com"
-      class=""
-      target="_self"
-      title=""
-      id=""
-      rel=""
-    >
+    <a href="https://graphcms.com" target="_self"     >
       Testing Link
     </a>
   </h2><h2>
-    <a
-      href="https://graphcms.com"
-      class=""
-      target="_self"
-      title=""
-      id=""
-      rel=""
-    >
+    <a href="https://graphcms.com" target="_self"     >
       Link
     </a>
    2</h2><table><tbody><tr><td><p>Row 1 - Col 1</p></td><td><p>Row 1 - Col 2</p></td></tr></tbody></table>`);
@@ -146,14 +132,7 @@ describe('@graphcms/rich-text-html-renderer', () => {
     const html = astToHtmlString({ content: linkContent });
 
     expect(html).toEqual(`
-    <a
-      href="https://graphcms.com"
-      class="text-white"
-      target="_blank"
-      title="GraphCMS website"
-      id="test"
-      rel="noreferrer"
-    >
+    <a href="https://graphcms.com" target="_blank" class="text-white" rel="noreferrer" title="GraphCMS website" id="test" rel="noreferrer">
       GraphCMS
     </a>
   `);
@@ -225,14 +204,7 @@ describe('@graphcms/rich-text-html-renderer', () => {
     const html = astToHtmlString({ content: imageContent });
 
     expect(html).toEqual(`
-    <img
-      loading="lazy"
-      src="https://media.graphassets.com/output=format:webp/resize=,width:667,height:1000/8xrjYm4CR721mAZ1YAoy"
-      width="667"
-      height="1000"
-      alt="photo-1564631027894-5bdb17618445.jpg"
-      title="photo-1564631027894-5bdb17618445.jpg"
-    />
+    <img loading="lazy" src="https://media.graphassets.com/output=format:webp/resize=,width:667,height:1000/8xrjYm4CR721mAZ1YAoy" width="667" height="1000" alt="photo-1564631027894-5bdb17618445.jpg" title="photo-1564631027894-5bdb17618445.jpg" />
   `);
   });
 
@@ -251,13 +223,7 @@ describe('@graphcms/rich-text-html-renderer', () => {
     const html = astToHtmlString({ content: videoContent });
 
     expect(html).toEqual(`
-    <video
-      src="https://media.graphassets.com/oWd7OYr5Q5KGRJW9ujRO"
-      controls
-      width="400"
-      height="400"
-      title="file_example_MP4_480_1_5MG.m4v"
-    >
+    <video src="https://media.graphassets.com/oWd7OYr5Q5KGRJW9ujRO" controls width="400" height="400" title="file_example_MP4_480_1_5MG.m4v">
       <p>
         Your browser doesn't support HTML5 video. Here is a
         <a href="https://media.graphassets.com/oWd7OYr5Q5KGRJW9ujRO">link to the video</a> instead.
@@ -350,8 +316,6 @@ describe('custom embeds and assets', () => {
     ];
 
     const html = astToHtmlString({ content: embedAssetContent, references });
-
-    console.log(html);
 
     expect(html).toMatchSnapshot(``);
   });
@@ -683,13 +647,7 @@ describe('custom embeds and assets', () => {
     });
 
     expect(html).toEqual(`<p>Inline asset
-    <video
-      src="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
-      controls
-      width="100%"
-      height="100%"
-      title=""
-    >
+    <video src="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS" controls width="100%" height="100%" >
       <p>
         Your browser doesn't support HTML5 video. Here is a
         <a href="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS">link to the video</a> instead.

--- a/packages/react-renderer/README.md
+++ b/packages/react-renderer/README.md
@@ -255,7 +255,7 @@ References are required on the `RichText` component to render embed assets.
 
 Imagine you have an embed `Post` on your Rich Text field. To render it, you can have a custom renderer. Let's see an example:
 
-```js
+```jsx
 import { RichText } from '@graphcms/rich-text-react-renderer';
 
 const content = [
@@ -330,6 +330,50 @@ References are required on the `RichText` component. You also need to include yo
 }
 ```
 
+### Link embeds
+
+The Rich Text Field also supports Link Embeds, which work similarly to normal embeds. Based on the model name, you can have a custom renderer for it. Example:
+
+```jsx
+import { RichText } from '@graphcms/rich-text-react-renderer';
+
+const content = [
+  {
+    type: 'link',
+    nodeId: 'post_id',
+    children: [
+      {
+        text: 'click here',
+      },
+    ],
+    nodeType: 'Post',
+  },
+];
+
+const references = [
+  {
+    id: 'post_id',
+    slug: 'graphcms-is-awesome',
+  },
+];
+
+function App() {
+  return (
+    <RichText
+      content={content}
+      references={references}
+      renderers={{
+        link: {
+          Post: ({ slug, children }) => {
+            return <a href={`/blog/${slug}`}>{children}</a>;
+          },
+        },
+      }}
+    />
+  );
+}
+```
+
 ## Empty elements
 
 By default, we remove empty headings from the element list to prevent SEO issues. Other elements, such as `thead` are also removed. You can find the complete list [here](https://github.com/GraphCMS/rich-text/blob/main/packages/types/src/index.ts#L168).
@@ -356,12 +400,12 @@ type Content = {
 
 ### Custom Embeds/Assets
 
-Depending on your reference query and model, fields may change, which applies to types. To have a better DX using the package, we have `EmbedProps` type that you can import from `@graphcms/rich-text-types` (you may need to install it if you don't have done it already).
+Depending on your reference query and model, fields may change, which applies to types. To have a better DX using the package, we have `EmbedProps` and `LinkEmbedProps` types that you can import from `@graphcms/rich-text-types` (you may need to install it if you don't have done it already).
 
 In this example, we have seen how to write a renderer for a `Post` model, but it applies the same way to any other model and `Asset` on your project.
 
 ```tsx
-import { EmbedProps } from '@graphcms/rich-text-types';
+import { EmbedProps, LinkEmbedProps } from '@graphcms/rich-text-types';
 
 type Post = {
   title: string;
@@ -378,12 +422,17 @@ function App() {
           Post: ({ title, description, slug }: EmbedProps<Post>) => {
             return (
               <div className="post">
-                <a href={`/post/${slug}`}>
+                <a href={`/blog/${slug}`}>
                   <h3>{title}</h3>
                   <p>{description}</p>
                 </a>
               </div>
             );
+          },
+        },
+        link: {
+          Post: ({ slug, children }: LinkEmbedProps<Post>) => {
+            return <a href={`/blog/${slug}`}>{children}</a>;
           },
         },
       }}

--- a/packages/react-renderer/src/RichText.tsx
+++ b/packages/react-renderer/src/RichText.tsx
@@ -81,10 +81,10 @@ function RenderElement({
     return <Fragment />;
   }
 
-  const isEmbed = type === 'embed';
+  const isEmbed = nodeId && nodeType;
 
   /**
-   * The .filter method returns an array with all found elements.
+   * The .filter method returns an array with all elements found.
    * Since there won't be duplicated ID's, it's safe to use the first element.
    */
   const referenceValues = isEmbed
@@ -145,14 +145,17 @@ function RenderElement({
 
   // Option 1
   if (isEmbed && nodeType !== 'Asset') {
-    const element = renderers?.embed?.[nodeType as string];
+    const element =
+      type === 'link'
+        ? renderers?.link?.[nodeType as string]
+        : renderers?.embed?.[nodeType as string];
 
     if (element !== undefined) {
       elementToRender = element;
     } else {
       // Option 1.1
       console.warn(
-        `[@graphcms/rich-text-react-renderer]: No renderer found for custom embed node type ${nodeType}.`
+        `[@graphcms/rich-text-react-renderer]: No renderer found for custom ${type} nodeType ${nodeType}.`
       );
       return <Fragment />;
     }

--- a/packages/react-renderer/src/defaultElements.tsx
+++ b/packages/react-renderer/src/defaultElements.tsx
@@ -64,4 +64,5 @@ export const defaultElements: Required<RichTextProps['renderers']> = {
     text: FallbackForCustomAsset,
   },
   embed: {},
+  link: {},
 };

--- a/packages/react-renderer/src/types.ts
+++ b/packages/react-renderer/src/types.ts
@@ -71,6 +71,9 @@ export type NodeRendererType = {
   embed?: {
     [key: string]: EmbedNodeRenderer | undefined;
   };
+  link?: {
+    [key: string]: EmbedNodeRenderer | undefined;
+  };
 };
 
 export type RichTextProps = {

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -70,7 +70,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <h2>
-
+          
           <a
             href="https://graphcms.com"
           >
@@ -78,7 +78,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
           </a>
         </h2>
         <h2>
-
+          
           <a
             href="https://graphcms.com"
           >
@@ -938,7 +938,7 @@ describe('custom embeds and assets', () => {
           >
             <p>
               Your browser doesn't support HTML5 video. Here is a
-
+               
               <a
                 href="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
               >

--- a/packages/react-renderer/test/RichText.test.tsx
+++ b/packages/react-renderer/test/RichText.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { RichText } from '@graphcms/rich-text-react-renderer';
-import { RichTextContent, EmbedProps } from '@graphcms/rich-text-types';
+import {
+  RichTextContent,
+  EmbedProps,
+  LinkEmbedProps,
+} from '@graphcms/rich-text-types';
 
 import {
   defaultContent as content,
@@ -66,7 +70,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <h2>
-          
+
           <a
             href="https://graphcms.com"
           >
@@ -74,7 +78,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
           </a>
         </h2>
         <h2>
-          
+
           <a
             href="https://graphcms.com"
           >
@@ -422,7 +426,7 @@ describe('@graphcms/rich-text-react-renderer', () => {
 });
 
 describe('custom embeds and assets', () => {
-  it('should render embed video, image, and audio assets', () => {
+  it('should render video, image, and audio assets', () => {
     const references = [
       {
         id: 'cknjbzowggjo90b91kjisy03a',
@@ -546,6 +550,16 @@ describe('custom embeds and assets', () => {
         nodeType: 'Asset',
       },
       {
+        type: 'link',
+        nodeId: 'link_id',
+        children: [
+          {
+            text: 'click here',
+          },
+        ],
+        nodeType: 'Article',
+      },
+      {
         type: 'embed',
         nodeId: 'custom_post_id',
         children: [
@@ -572,6 +586,10 @@ describe('custom embeds and assets', () => {
         id: '',
         title: 'GraphCMS is awesome :rocket:',
       },
+      {
+        id: '',
+        slug: 'graphcms-is-awesome',
+      },
     ];
 
     /**
@@ -581,7 +599,7 @@ describe('custom embeds and assets', () => {
       <RichText content={content} references={references} />
     );
 
-    expect(console.error).toHaveBeenCalledTimes(3);
+    expect(console.error).toHaveBeenCalledTimes(4);
     expect(container).toMatchInlineSnapshot(`<div />`);
   });
 
@@ -723,6 +741,52 @@ describe('custom embeds and assets', () => {
     `);
   });
 
+  it('should render custom link models', () => {
+    const content: RichTextContent = [
+      {
+        type: 'link',
+        nodeId: 'my_article',
+        children: [
+          {
+            text: 'click here',
+          },
+        ],
+        nodeType: 'Article',
+      },
+    ];
+
+    const references = [
+      {
+        id: 'my_article',
+        slug: 'introducing-link-embeds',
+      },
+    ];
+
+    const { container } = render(
+      <RichText
+        content={content}
+        references={references}
+        renderers={{
+          link: {
+            Article: ({ slug, children }: LinkEmbedProps<{ slug: string }>) => {
+              return <a href={`/${slug}`}>{children}</a>;
+            },
+          },
+        }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <a
+          href="/introducing-link-embeds"
+        >
+          click here
+        </a>
+      </div>
+    `);
+  });
+
   it(`should show a warning if embeds are found but there aren't any renderer for it`, () => {
     console.warn = jest.fn();
 
@@ -737,6 +801,16 @@ describe('custom embeds and assets', () => {
         ],
         nodeType: 'Post',
       },
+      {
+        type: 'link',
+        nodeId: 'link_id',
+        children: [
+          {
+            text: 'My link',
+          },
+        ],
+        nodeType: 'Article',
+      },
     ];
 
     const references = [
@@ -744,13 +818,17 @@ describe('custom embeds and assets', () => {
         id: 'custom_post_id',
         title: 'GraphCMS is awesome :rocket:',
       },
+      {
+        id: 'link_id',
+        title: 'My link',
+      },
     ];
 
     const { container } = render(
       <RichText content={content} references={references} />
     );
 
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(2);
     expect(container).toMatchInlineSnapshot(`<div />`);
   });
 
@@ -860,7 +938,7 @@ describe('custom embeds and assets', () => {
           >
             <p>
               Your browser doesn't support HTML5 video. Here is a
-               
+
               <a
                 href="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
               >

--- a/packages/react-renderer/test/__snapshots__/RichText.test.tsx.snap
+++ b/packages/react-renderer/test/__snapshots__/RichText.test.tsx.snap
@@ -123,48 +123,6 @@ exports[`@graphcms/rich-text-react-renderer should replace all
 </div>
 `;
 
-exports[`custom embeds and assets should render embed video, image, and audio assets 1`] = `
-<div>
-  <img
-    loading="lazy"
-    src="https://media.graphassets.com/dsQtt0ARqO28baaXbVy9"
-  />
-  <video
-    controls=""
-    height="100%"
-    src="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
-    width="100%"
-  >
-    <p>
-      Your browser doesn't support HTML5 video. Here is a
-       
-      <a
-        href="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
-      >
-        link to the video
-      </a>
-       instead.
-    </p>
-  </video>
-  <audio
-    controls=""
-    src="https://media.graphassets.com/H9eZ7CISSBpAKxqdSwzg"
-    style="display: block; max-width: 100%; height: auto;"
-  >
-    <p>
-      Your browser doesn't support HTML5 audio. Here is a
-       
-      <a
-        href="https://media.graphassets.com/H9eZ7CISSBpAKxqdSwzg"
-      >
-        link to the audio
-      </a>
-       instead.
-    </p>
-  </audio>
-</div>
-`;
-
 exports[`custom embeds and assets should render video, image, and audio assets 1`] = `
 <div>
   <img

--- a/packages/react-renderer/test/__snapshots__/RichText.test.tsx.snap
+++ b/packages/react-renderer/test/__snapshots__/RichText.test.tsx.snap
@@ -164,3 +164,45 @@ exports[`custom embeds and assets should render embed video, image, and audio as
   </audio>
 </div>
 `;
+
+exports[`custom embeds and assets should render video, image, and audio assets 1`] = `
+<div>
+  <img
+    loading="lazy"
+    src="https://media.graphassets.com/dsQtt0ARqO28baaXbVy9"
+  />
+  <video
+    controls=""
+    height="100%"
+    src="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
+    width="100%"
+  >
+    <p>
+      Your browser doesn't support HTML5 video. Here is a
+       
+      <a
+        href="https://media.graphassets.com/7M0lXLdCQfeIDXnT2SVS"
+      >
+        link to the video
+      </a>
+       instead.
+    </p>
+  </video>
+  <audio
+    controls=""
+    src="https://media.graphassets.com/H9eZ7CISSBpAKxqdSwzg"
+    style="display: block; max-width: 100%; height: auto;"
+  >
+    <p>
+      Your browser doesn't support HTML5 audio. Here is a
+       
+      <a
+        href="https://media.graphassets.com/H9eZ7CISSBpAKxqdSwzg"
+      >
+        link to the audio
+      </a>
+       instead.
+    </p>
+  </audio>
+</div>
+`;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -119,8 +119,14 @@ export type EmbedProps<T = any> = T & {
   isInline?: boolean;
 };
 
+export type LinkEmbedProps<T = any> = T & {
+  nodeId: string;
+  nodeType: string;
+  children: any;
+};
+
 export interface EmbedElement extends EmbedProps, Element {
-  type: 'embed';
+  type: 'embed' | 'link';
 }
 
 export type ElementNode =

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -114,12 +114,14 @@ export interface IFrameElement extends IFrameProps, Element {
 }
 
 export type EmbedProps<T = any> = T & {
+  id: string;
   nodeId: string;
   nodeType: string;
   isInline?: boolean;
 };
 
 export type LinkEmbedProps<T = any> = T & {
+  id: string;
   nodeId: string;
   nodeType: string;
   children: any;


### PR DESCRIPTION
This PR adds support for Link Embeds for both packages, React and HTML. The documentation and tests for the new feature were also added.