### PR TITLE
fix: img tag conversion to AST

### DIFF
--- a/packages/html-to-slate-ast/src/index.ts
+++ b/packages/html-to-slate-ast/src/index.ts
@@ -55,10 +55,9 @@ const ELEMENT_TAGS: Record<
       : '(Image)';
     if (href === null) return {};
     return {
-      type: 'link',
-      href: sanitizeUrl(href),
+      type: 'image',
+      src: sanitizeUrl(href),
       title,
-      openInNewTab: true,
     };
   },
   PRE: () => ({ type: 'code-block' }),


### PR DESCRIPTION
html-to-ast wrongly transforms `img` tags into links, this PR fixes it